### PR TITLE
Fix `ubuntu-latest` (Ubuntu 24.04) support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,72 @@ on:
   push:
 
 jobs:
-  Linux:
-    name: Linux (${{ matrix.box }}) (${{ matrix.provider }})
+  Ubuntu2204:
+    name: Ubuntu 22.04 (${{ matrix.box }}) (${{ matrix.provider }})
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        box:
+          - generic/arch
+        provider:
+          - libvirt
+          - virtualbox
+      fail-fast: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set `CPUS`
+        run: |
+          echo "CPUS=$(nproc)" >> ${GITHUB_ENV}
+
+      - name: Provision VM
+        uses: ./
+        with:
+          box: ${{ matrix.box }}
+          cpus: ${{ env.CPUS }}
+          provider: ${{ matrix.provider }}
+
+      - name: Run Test (/etc/os-release) (VM)
+        run: |
+          source /etc/os-release
+          if [ "${NAME}" = "Arch Linux" ]; then
+            echo "Arch Linux detected."
+          else
+            echo "Arch Linux not detected."
+            exit 1
+          fi
+        shell: bash --noprofile --norc -euo pipefail {0}
+
+      - name: Run Test (/etc/os-release) (Host)
+        run: |
+          source /etc/os-release
+          if [ "${NAME}" = "Arch Linux" ]; then
+            echo "Arch Linux detected."
+            exit 1
+          else
+            echo "Arch Linux not detected."
+          fi
+        shell: /bin/bash --noprofile --norc -euo pipefail {0}
+
+      - name: Prepare Test (working-directory) (VM)
+        run: |
+          mkdir new_working_directory
+        shell: bash --noprofile --norc -euo pipefail {0}
+
+      - name: Run Test (working-directory) (VM)
+        run: |
+          if [ "$(basename ${PWD})" = "new_working_directory" ]; then
+            echo "Expected working directory detected."
+          else
+            echo "Expected working directory not detected."
+            exit 1
+          fi
+        shell: bash --noprofile --norc -euo pipefail {0}
+        working-directory: new_working_directory
+
+  UbuntuLatest:
+    name: Ubuntu Latest (${{ matrix.box }}) (${{ matrix.provider }})
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/action.yml
+++ b/action.yml
@@ -88,6 +88,8 @@ runs:
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
+        curl https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
         sudo apt-get update
         sudo apt-get --yes install \
           vagrant
@@ -100,7 +102,8 @@ runs:
       run: |
         sudo apt-get --yes install \
           libvirt-daemon-system \
-          qemu
+          libvirt-dev \
+          qemu-system
         sudo setfacl -m user:$USER:rw /var/run/libvirt/libvirt-sock
       shell: bash
       if: runner.os == 'Linux' && env.PROVIDER == 'libvirt'

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
     options:
       - libvirt
       - virtualbox
-    type: string
+    type: choice
   provision_commands:
     default: >-
       echo 'AcceptEnv *' >> /etc/ssh/sshd_config;

--- a/action.yml
+++ b/action.yml
@@ -88,11 +88,18 @@ runs:
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
-        curl https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
-        echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+        if [ "${ImageOS}" = "ubuntu24" ]; then
+          # Ubuntu 24.04 no longer provides Vagrant, install from Hashicorp
+          sudo bash -c 'curl --silent https://apt.releases.hashicorp.com/gpg | gpg --dearmor > /usr/share/keyrings/hashicorp-archive-keyring.gpg'
+          sudo bash -c 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com '$(lsb_release -cs)' main" > /etc/apt/sources.list.d/hashicorp.list'
+        fi
         sudo apt-get update
         sudo apt-get --yes install \
           vagrant
+        if [ "${ImageOS}" = "ubuntu24" ]; then
+          # Vagrant from Hashicorp installs a bash wrapper
+          sudo ln --force --symbolic /opt/vagrant/bin/vagrant /usr/bin/vagrant
+        fi
       shell: bash
       if: runner.os == 'Linux'
 
@@ -206,21 +213,25 @@ runs:
 
     - name: Generate /bin/bash override script
       run: |
-        echo "#!/bin/bash" | sudo tee /usr/local/bin/bash
-        echo "SCRIPT=\$(mktemp)" | sudo tee -a /usr/local/bin/bash
-        echo "echo \"#!/usr/bin/env bash\" >> \${SCRIPT}" | sudo tee -a /usr/local/bin/bash
-        echo "echo \"cd \${PWD}\" >> \${SCRIPT}" | sudo tee -a /usr/local/bin/bash
-        echo "echo \"set -euxo pipefail\" >> \${SCRIPT}" | sudo tee -a /usr/local/bin/bash
-        echo "echo \"bash \$@\" >> \${SCRIPT}" | sudo tee -a /usr/local/bin/bash
-        echo "mv \${SCRIPT} ${{ runner.temp }}/command.sh" | sudo tee -a /usr/local/bin/bash
-        echo "chmod a+x ${{ runner.temp }}/command.sh" | sudo tee -a /usr/local/bin/bash
-        echo "rsync --archive --delete ${{ github.workspace }}/ vagrantbox:${{ github.workspace }}/" | sudo tee -a /usr/local/bin/bash
-        echo "rsync --archive --delete ${{ runner.temp }}/ vagrantbox:${{ runner.temp }}/" | sudo tee -a /usr/local/bin/bash
-        echo "vagrant ssh --command \"${{ runner.temp }}/command.sh\"" | sudo tee -a /usr/local/bin/bash
-        echo "EXIT_STATUS=\$?" | sudo tee -a /usr/local/bin/bash
-        echo "rsync --archive --delete vagrantbox:${{ github.workspace }}/ ${{ github.workspace }}/" | sudo tee -a /usr/local/bin/bash
-        echo "rsync --archive --delete vagrantbox:${{ runner.temp }}/ ${{ runner.temp }}/" | sudo tee -a /usr/local/bin/bash
-        echo "exit \${EXIT_STATUS}" | sudo tee -a /usr/local/bin/bash
+        cat > bash <<EOF
+        #!/bin/bash
+        set -euxo pipefail
+        SCRIPT=\$(mktemp)
+        echo "#!/usr/bin/env bash" >> \${SCRIPT}
+        echo "cd \${PWD}" >> \${SCRIPT}
+        echo "set -euxo pipefail" >> \${SCRIPT}
+        echo "bash \$@" >> \${SCRIPT}
+        mv \${SCRIPT} ${{ runner.temp }}/command.sh
+        chmod a+x ${{ runner.temp }}/command.sh
+        rsync --archive --delete ${{ github.workspace }}/ vagrantbox:${{ github.workspace }}/
+        rsync --archive --delete ${{ runner.temp }}/ vagrantbox:${{ runner.temp }}/
+        vagrant ssh --command "${{ runner.temp }}/command.sh"
+        EXIT_STATUS=\$?
+        rsync --archive --delete vagrantbox:${{ github.workspace }}/ ${{ github.workspace }}/
+        rsync --archive --delete vagrantbox:${{ runner.temp }}/ ${{ runner.temp }}/
+        exit \${EXIT_STATUS}
+        EOF
+        sudo mv bash /usr/local/bin/bash
         sudo chmod +x /usr/local/bin/bash
       shell: bash
 
@@ -230,7 +241,7 @@ runs:
       with:
         post: >-
           if [ ! -f ${{ inputs.vagrant_box_descriptor }} ]; then
-          vagrant ssh --command "${{ inputs.pre_package_commands }}";
-          vagrant package --output ${{ inputs.vagrant_box_descriptor }};
+            vagrant ssh --command "${{ inputs.pre_package_commands }}";
+            vagrant package --output ${{ inputs.vagrant_box_descriptor }};
           fi
         post-shell: /bin/bash


### PR DESCRIPTION
### Two issues prevented the existing action from working
- `Ubuntu 24.04` no longer provides `vagrant` package
  - Due to the adoption of the Business Source License (BSL) by Vagrant
- `vagrant` package from `Hashicorp` installs to `/opt` with a `bash` wrapper in `/usr/bin/vagrant`
  - This was breaking the `bash` override method used by this action


Also added tests for `ubuntu-22.04`